### PR TITLE
Fix vscode-insiders link

### DIFF
--- a/links/scalable/apps/com.visualstudio.code.insiders.svg
+++ b/links/scalable/apps/com.visualstudio.code.insiders.svg
@@ -1,1 +1,1 @@
-visualstudiocode.svg
+visual-studio-code-insiders.svg


### PR DESCRIPTION
VS Code insiders is currently using the normal VS Code svg file, instead of its own svg file. I believe this should fix it. 