### PR TITLE
Fixed ERROR: link target doesn't exist aegisub.svg

### DIFF
--- a/links/scalable/apps/org.aegisub.Aegisub.svg
+++ b/links/scalable/apps/org.aegisub.Aegisub.svg
@@ -1,1 +1,0 @@
-aegisub.svg


### PR DESCRIPTION
I was packaging this theme for @openSUSE and this broke the build.