### PR TITLE
Added TOML mimetype

### DIFF
--- a/src/scalable/mimetypes/application-toml.svg
+++ b/src/scalable/mimetypes/application-toml.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64"
+   height="64"
+   version="1.1"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
+   sodipodi:docname="text-toml.svg"
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs24" />
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="8.7393979"
+     inkscape:cx="-7.0370981"
+     inkscape:cy="38.561009"
+     inkscape:window-width="2560"
+     inkscape:window-height="1378"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1140" />
+  <path
+     d="M 2.3788388,0.26777918 14.552165,0.2688375 V 15.610509 H 2.3791034 V 0.26777918 Z"
+     fill="#fafafa"
+     id="path2"
+     style="stroke-width:0.26458" />
+  <path
+     d="m 2.2489829,0.13268463 12.4347311,0.001064 V 15.743763 H 2.2489829 Z"
+     fill="none"
+     stroke="#4f6698"
+     stroke-linejoin="round"
+     stroke-opacity="0.267"
+     stroke-width="0.264485"
+     id="path4" />
+  <rect
+     y="0.00028492432"
+     width="16.933121"
+     height="16.933121"
+     rx="0"
+     ry="0"
+     fill="none"
+     opacity="0.75"
+     id="rect6"
+     x="0"
+     style="stroke-width:0.26458" />
+  <path
+     d="M 4.233,2.381 V 2.646 H 5.077 V 2.38 Z m 0.955,0 v 0.265 h 0.8 V 2.38 Z m 0.91,0 v 0.265 h 0.7 V 2.38 Z m 0.811,0 V 2.646 H 7.22 V 2.38 Z m 0.422,0 V 2.646 H 8.019 V 2.38 Z m 0.81,0 V 2.646 H 9.918 V 2.38 Z M 4.233,3.175 V 3.44 H 5.577 V 3.175 Z m 1.477,0 V 3.44 H 6.354 V 3.175 Z m 0.766,0 V 3.44 h 0.3 V 3.175 Z m 0.433,0 V 3.44 H 7.487 V 3.175 Z m 0.71,0 V 3.44 H 8.197 V 3.175 Z m 0.7,0 V 3.44 H 9.263 V 3.175 Z m 1.077,0 V 3.44 h 1.233 V 3.175 Z M 7.41,13.494 v 0.264 h 0.866 v -0.264 z m 0.977,0 v 0.264 h 0.8 v -0.264 z m 0.921,0 v 0.264 h 0.689 v -0.264 z m 0.8,0 v 0.264 h 1.099 v -0.264 z m 1.221,0 v 0.264 h 1.788 V 13.494 Z M 6.41,12.7 v 0.265 H 6.698 V 12.7 Z m 0.366,0 v 0.265 H 7.353 V 12.7 Z m 0.666,0 v 0.265 H 8.019 V 12.7 Z m 0.755,0 v 0.265 H 9.119 V 12.7 Z m 1.033,0 v 0.265 h 1.199 V 12.7 Z m 1.365,0 v 0.265 h 0.81 V 12.7 Z m 0.91,0 v 0.265 h 0.19 V 12.7 Z m -7.272,0.794 h 1.08 v 0.264 H 4.233 Z M 4.234,12.7 v 0.265 h 1.31 V 12.7 Z m 1.41,0 v 0.265 H 6.276 V 12.7 Z m -0.223,0.794 v 0.264 H 6.61 v -0.264 z"
+     fill="#b4bfd8"
+     id="path10"
+     sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+  <path
+     d="M3.704 3.704h3.97v.529h-3.97z"
+     fill="#fafafa"
+     id="path12" />
+  <path
+     d="M3.968 4.498h3.704v.529H3.968zm5.292 7.408h3.704v.529H9.26z"
+     fill="#fafafa"
+     id="path14" />
+  <g
+     id="g1140"
+     transform="translate(20.04861,0.51196701)">
+    <g
+       id="XMLID_11_"
+       style="fill:#a2a2a2;stroke-width:11.2504;fill-opacity:1"
+       transform="matrix(0.02351723,0,0,0.02351723,-16.21953,2.741369)">
+      <path
+         id="XMLID_12_"
+         class="st1"
+         d="m 28.6,30.5 h 75.1 V 67.8 H 69 v 262.7 h 34.7 V 368 H 28.6 Z"
+         style="fill:#a2a2a2;stroke-width:11.2504;fill-opacity:1" />
+    </g>
+    <g
+       id="XMLID_4_"
+       style="stroke-width:11.2504;fill:#666666"
+       transform="matrix(0.02351723,0,0,0.02351723,-16.21953,2.741369)">
+      <path
+         id="XMLID_6_"
+         d="m 276.4,101.5 v 39.1 H 216.3 V 322.5 H 174 V 140.6 h -60.4 v -39.1 z"
+         style="stroke-width:11.2504;fill:#666666" />
+    </g>
+    <g
+       id="XMLID_3_"
+       style="fill:#a2a2a2;stroke-width:11.2504;fill-opacity:1"
+       transform="matrix(0.02351723,0,0,0.02351723,-16.21953,2.741369)">
+      <path
+         id="XMLID_5_"
+         class="st1"
+         d="m 365.7,368 h -75.1 v -37.3 h 34.7 V 68 H 290.6 V 30.5 h 75.1 z"
+         style="fill:#a2a2a2;stroke-width:11.2504;fill-opacity:1" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
One more mimetype - this time for TOML.

The [official icon](https://github.com/toml-lang/toml/blob/master/logos/toml.svg) fits this theme quite nicely IMHO.

Unfortunately, toml is [not yet an "official" iana mimetype](https://github.com/toml-lang/toml/issues/574), but it is clear that it will be named [`application/toml`](https://toml.io/en/v1.0.0#mime-type).
The freedesktop project has also [adoped it](https://gitlab.freedesktop.org/xdg/shared-mime-info/-/merge_requests/125), so why not add support for Qogir :slightly_smiling_face: 

