### PR TITLE
Deleted link icon org.gnome.TextEditor.svg

### DIFF
--- a/links/scalable/apps/org.gnome.TextEditor.svg
+++ b/links/scalable/apps/org.gnome.TextEditor.svg
@@ -1,1 +1,0 @@
-text-editor.svg


### PR DESCRIPTION
Forgot to do that in the past PR