### PR TITLE
:bug: Remove symbolic links for musescore

### DIFF
--- a/links/scalable/mimetypes/application-x-musescore+xml.svg
+++ b/links/scalable/mimetypes/application-x-musescore+xml.svg
@@ -1,1 +1,0 @@
-text-x-lilypond.svg

--- a/links/scalable/mimetypes/application-x-musescore.svg
+++ b/links/scalable/mimetypes/application-x-musescore.svg
@@ -1,1 +1,0 @@
-text-x-lilypond.svg


### PR DESCRIPTION
I have removed the symlinks for the MuseScore icons that were pointing to LilyPond, as these are no longer required and were preventing the new icons from displaying correctly.